### PR TITLE
Allow custom JMX URL

### DIFF
--- a/manifests/metrics.pp
+++ b/manifests/metrics.pp
@@ -23,6 +23,7 @@
 #       }
 #   ]
 #
+# $jmx_url              - Custom jmx url.                 Optional.
 # $jmx_alias            - Server alias name.              Optional.
 # $jmx_username         - JMX username (if there is one)  Optional.
 # $jmx_password         - JMX password (if there is one)  Optional.
@@ -38,6 +39,7 @@
 define jmxtrans::metrics(
     $jmx,
     $objects,
+    $jmx_url              = undef,
     $jmx_alias            = undef,
     $jmx_username         = undef,
     $jmx_password         = undef,

--- a/templates/jmxtrans.json.erb
+++ b/templates/jmxtrans.json.erb
@@ -11,6 +11,9 @@ valid_statsd_settings  = ['bucketType']
 { "servers":
   [ { "host": "<%= jmx_host %>"
     , "port": <%= jmx_port %>
+<% if @jmx_url -%>
+    , "url": "<%= @jmx_url %>"
+<% end -%>
 <% if @jmx_alias -%>
     , "alias": "<%= @jmx_alias %>"
 <% end -%>


### PR DESCRIPTION
Some apps and devices expose jmx on a URL for example, ForumSentry API Gateway appliances use a JMX Connection URL like: service:jmx:rmi://IP_ADDRESS/jndi/rmi://IP_ADDRESS:1099/fsjmx

Looking at the jmxtrans code at: https://github.com/jmxtrans/jmxtrans/blob/a572243e753da32b5ae0f1e8eb8891b41f9db7d1/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java#L377

and:

https://github.com/jmxtrans/jmxtrans/blob/a572243e753da32b5ae0f1e8eb8891b41f9db7d1/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java#L167

you can specify the URL in the JSON config file.
